### PR TITLE
Open on double click + other changes

### DIFF
--- a/lib/open-unsupported-files.coffee
+++ b/lib/open-unsupported-files.coffee
@@ -6,20 +6,22 @@ module.exports =
       default: 'doc,xls,ppt,docx,xlsx,pptx,pdf,rtf,zip,7z,rar,tar,gz,bz2,exe,bat'
 
   activate: ->
-    @extensions = atom.config.get('open-unsupported-files.extensions')?.split(',')
+    @extensions = atom.config.get('open-unsupported-files.extensions')?.toLowerCase().split(',')
     {requirePackages} = require 'atom-utils'
+
     requirePackages('tree-view').then ([treeView]) =>
       if tv = treeView.treeView
-        @originalEntryClicked = tv.entryClicked
-        tv.entryClicked =  (e) =>
-          shell = require('shell')
-          entry = e.currentTarget
-          return @originalEntryClicked.call(tv,e) unless entry.constructor.name is 'tree-view-file'
-          filepath = entry.file.path
-          return @originalEntryClicked.call(tv,e) unless filepath
-          filename = entry.file.name
-          if filename?.substring(filename.lastIndexOf('.') + 1 ).toLowerCase() in @extensions
-            shell.openItem(filepath)
+        @originalFileViewEntryClicked = tv.fileViewEntryClicked
+
+        tv.fileViewEntryClicked = (e) =>
+          path = e.currentTarget.getPath()
+          filename = e.currentTarget.file.name
+          extension = filename?.substring(filename.lastIndexOf('.') + 1).toLowerCase()
+
+          if extension in @extensions
+            if e.originalEvent?.detail is 2
+              shell = require('shell')
+              shell.openItem(path)
             return false
           else
-            @originalEntryClicked.call(tv,e)
+            @originalFileViewEntryClicked.call(tv, e)


### PR DESCRIPTION
Use fileViewEntryClicked instead of entryClicked, which removes the need for some checks.
Add toLowerCase to the default extensions config value.

Result of issue #9.